### PR TITLE
feat: add Swagger API documentation and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@
 .resultset.json
 .resultset.json.lock
 /coverage
+
+# Ignore swagger files
+/swagger/v1/swagger.json

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,10 @@ gem 'thruster', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 
+# Swagger
+gem 'rswag-api'
+gem 'rswag-ui'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows], require: 'debug/prelude'
@@ -54,6 +58,9 @@ group :development, :test do
   # Tests
   gem 'faker'
   gem 'rspec-rails'
+
+  # Swagger
+  gem 'rswag-specs'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt_pbkdf (1.1.1)
@@ -121,6 +123,9 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.13.2)
+    json-schema (5.2.2)
+      addressable (~> 2.8)
+      bigdecimal (~> 3.1)
     kamal (2.7.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -191,6 +196,7 @@ GEM
     psych (5.2.6)
       date
       stringio
+    public_suffix (6.0.2)
     puma (7.0.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -258,6 +264,17 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.5)
+    rswag-api (2.16.0)
+      activesupport (>= 5.2, < 8.1)
+      railties (>= 5.2, < 8.1)
+    rswag-specs (2.16.0)
+      activesupport (>= 5.2, < 8.1)
+      json-schema (>= 2.2, < 6.0)
+      railties (>= 5.2, < 8.1)
+      rspec-core (>= 2.14)
+    rswag-ui (2.16.0)
+      actionpack (>= 5.2, < 8.1)
+      railties (>= 5.2, < 8.1)
     rubocop (1.80.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -372,6 +389,9 @@ DEPENDENCIES
   rails (~> 8.0.2, >= 8.0.2.1)
   rspec-json_expectations
   rspec-rails
+  rswag-api
+  rswag-specs
+  rswag-ui
   rubocop
   rubocop-performance
   rubocop-rails

--- a/README.md
+++ b/README.md
@@ -74,6 +74,32 @@ You can set up and run the application using either the `Makefile` commands or t
    - `GET /api/menu_items/:id` - Get a specific menu item
    - `POST /api/import_restaurants` - Import restaurant data from a JSON payload
 
+## Generating API Documentation with Swagger
+
+The API includes Swagger-generated documentation for easy exploration of endpoints and their details.
+
+### Using Makefile
+
+1. Generate and view the Swagger API documentation:
+
+   ```bash
+   make api_docs
+   ```
+
+   This command:
+   - Creates and migrates the database (`bin/rails db:create db:migrate`).
+   - Runs the API request specs to ensure endpoints are working (`bundle exec rspec spec/requests/api`).
+   - Starts the Rails server (`rails s`).
+
+2. Access the Swagger documentation:
+
+   - Open your browser and navigate to `http://localhost:3000/api-docs/index.html`.
+
+### Notes
+
+- Ensure the Rails server is running to access the Swagger documentation.
+- The Swagger interface provides an interactive way to explore all available API endpoints, including request/response formats and example payloads.
+
 ## Importing Restaurant Data
 
 The API supports importing restaurant data (including menus and menu items) from a JSON file or payload. This can be done via an HTTP endpoint or a rake task.

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,3 @@
+Rswag::Api.configure do |config|
+  config.openapi_root = Rails.root.join('swagger').to_s
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,3 @@
+Rswag::Ui.configure do |config|
+  config.openapi_endpoint '/api-docs/v1/swagger.json', 'Restaurant Menu API V1'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,7 @@ Rails.application.routes.draw do
 
     resources :import_restaurants, only: %i[create]
   end
+
+  mount Rswag::Api::Engine => '/api-docs'
+  mount Rswag::Ui::Engine => '/api-docs'
 end

--- a/makefile
+++ b/makefile
@@ -17,3 +17,8 @@ test_coverage:
 import:
 	bin/rails db:create db:migrate
 	rake 'import:json[restaurant_data.json]'
+
+api_docs:
+	bin/rails db:create db:migrate
+	bundle exec rspec spec/requests/api
+	rails s

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,8 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 # that will avoid rails generators crashing because migrations haven't been run yet
 # return unless Rails.env.test?
 require 'rspec/rails'
+require 'swagger_helper'
+require File.expand_path('../config/environment', __dir__)
 require 'faker'
 require 'rspec/json_expectations'
 require 'shoulda/matchers'

--- a/spec/requests/api/import_restaurants_spec.rb
+++ b/spec/requests/api/import_restaurants_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe 'Import Restaurants API', openapi_spec: 'v1/swagger.json', type: :request do
+  path '/api/import_restaurants' do
+    post 'Import restaurant data' do
+      tags 'Imports'
+      consumes 'application/json'
+      produces 'application/json'
+      description 'Imports restaurant data from a JSON payload, processing menus and items'
+
+      parameter name: :import_data, in: :body, schema: { '$ref' => '#/components/schemas/ImportRequest' }
+
+      response 200, 'successful' do
+        schema '$ref' => '#/components/schemas/ImportResponse'
+
+        let(:valid_payload) do
+          {
+            restaurants: [
+              {
+                name: 'API Test',
+                menus: [
+                  {
+                    name: 'breakfast',
+                    menu_items: [
+                      { name: 'Pancakes', price: 7.0 }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }.to_json
+        end
+
+        let(:import_data) { valid_payload }
+
+        after do |example|
+          if response&.body
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                examples: { example: { value: JSON.parse(response.body, symbolize_names: true) } }
+              }
+            }
+          end
+        end
+
+        run_test!
+      end
+
+      response 400, 'bad request (invalid JSON)' do
+        schema '$ref' => '#/components/schemas/ImportResponse'
+
+        let(:import_data) { 'invalid' }
+
+        run_test!
+      end
+
+      response 200, 'invalid data (missing restaurant name)' do
+        schema '$ref' => '#/components/schemas/ImportResponse'
+
+        let(:import_data) do
+          { restaurants: [{ name: nil, menus: [] }] }.to_json
+        end
+
+        run_test! do
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body, symbolize_names: true)).to include(
+            success: true,
+            logs: array_including(match(/Error processing restaurant : Missing restaurant name/))
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/menu_items_spec.rb
+++ b/spec/requests/api/menu_items_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'Menu Items API', openapi_spec: 'v1/swagger.json', type: :request do
+  path '/api/menu_items' do
+    get 'List all menu items' do
+      tags 'Menu Items'
+      produces 'application/json'
+      description 'Returns a list of all menu items'
+
+      response 200, 'successful' do
+        schema type: :array, items: { '$ref' => '#/components/schemas/MenuItem' }
+
+        let!(:menu_items) { create_list(:menu_item, 2) }
+
+        after do |example|
+          if response&.body
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                examples: { example: { value: JSON.parse(response.body, symbolize_names: true) } }
+              }
+            }
+          end
+        end
+
+        run_test! do
+          expect(response.body).to eq(MenuItemBlueprint.render(menu_items, view: :with_id))
+        end
+      end
+    end
+  end
+
+  path '/api/menu_items/{id}' do
+    get 'Get a specific menu item' do
+      tags 'Menu Items'
+      produces 'application/json'
+      description 'Returns details of a specific menu item'
+      parameter name: :id, in: :path, type: :integer, description: 'menu item ID', required: true
+
+      response 200, 'successful' do
+        schema '$ref' => '#/components/schemas/MenuItemDetails'
+
+        let(:menu_item) { create(:menu_item) }
+        let(:id) { menu_item.id }
+
+        after do |example|
+          if response&.body
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                examples: { example: { value: JSON.parse(response.body, symbolize_names: true) } }
+              }
+            }
+          end
+        end
+
+        run_test! do
+          expect(response.body).to eq(MenuItemBlueprint.render(menu_item, view: :details))
+        end
+      end
+
+      response 404, 'not found' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:id) { 999 }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/menus_spec.rb
+++ b/spec/requests/api/menus_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe 'Menus API', openapi_spec: 'v1/swagger.json', type: :request do
+  path '/api/restaurants/{restaurant_id}/menus' do
+    get 'List all menus for a restaurant' do
+      tags 'Menus'
+      produces 'application/json'
+      description 'Returns a list of menus for a specific restaurant'
+      parameter name: :restaurant_id, in: :path, type: :integer, description: 'ID do restaurante', required: true
+
+      response 200, 'successful' do
+        schema type: :array, items: { '$ref' => '#/components/schemas/Menu' }
+
+        let(:restaurant) { create(:restaurant) }
+        let(:restaurant_id) { restaurant.id }
+        let!(:menus) { create_list(:menu, 2, :with_menu_items, restaurant: restaurant) }
+
+        after do |example|
+          if response&.body
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                examples: { example: { value: JSON.parse(response.body, symbolize_names: true) } }
+              }
+            }
+          end
+        end
+
+        run_test! do
+          expect(response.body).to eq(MenuBlueprint.render(menus))
+        end
+      end
+
+      response 404, 'restaurant not found' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:restaurant_id) { 999 }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/restaurants/{restaurant_id}/menus/{id}' do
+    get 'Get a specific menu' do
+      tags 'Menus'
+      produces 'application/json'
+      description 'Returns details of a specific menu, including items'
+      parameter name: :restaurant_id, in: :path, type: :integer, description: 'restaurant ID', required: true
+      parameter name: :id, in: :path, type: :integer, description: 'menu ID', required: true
+
+      response 200, 'successful' do
+        schema '$ref' => '#/components/schemas/MenuWithItems'
+
+        let(:restaurant) { create(:restaurant) }
+        let(:restaurant_id) { restaurant.id }
+        let(:menu) { create(:menu, :with_menu_items, restaurant: restaurant) }
+        let(:id) { menu.id }
+
+        after do |example|
+          if response&.body
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                examples: { example: { value: JSON.parse(response.body, symbolize_names: true) } }
+              }
+            }
+          end
+        end
+
+        run_test! do
+          expect(response.body).to eq(MenuBlueprint.render(menu, view: :menu_items))
+        end
+      end
+
+      response 404, 'menu not found' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:restaurant) { create(:restaurant) }
+        let(:restaurant_id) { restaurant.id }
+        let(:id) { 999 }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/restaurants_spec.rb
+++ b/spec/requests/api/restaurants_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe 'Restaurants API', openapi_spec: 'v1/swagger.json', type: :request do
+  path '/api/restaurants' do
+    get 'List all restaurants' do
+      tags 'Restaurants'
+      produces 'application/json'
+      description 'Returns a list of all restaurants with menu details'
+
+      response 200, 'successful' do
+        schema type: :array, items: { '$ref' => '#/components/schemas/Restaurant' }
+
+        let!(:restaurants) { create_list(:restaurant, 2, :with_menus) }
+
+        after do |example|
+          if response&.body
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                examples: { example: { value: JSON.parse(response.body, symbolize_names: true) } }
+              }
+            }
+          end
+        end
+
+        run_test! do
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to eq(RestaurantBlueprint.render(restaurants, view: :detailed))
+        end
+      end
+    end
+  end
+
+  path '/api/restaurants/{id}' do
+    get 'Get a specific restaurant' do
+      tags 'Restaurants'
+      produces 'application/json'
+      description 'Returns details for a specific restaurant, including menus'
+      parameter name: :id, in: :path, type: :integer, description: 'ID do restaurante', required: true
+
+      response 200, 'successful' do
+        schema '$ref' => '#/components/schemas/Restaurant'
+
+        let(:restaurant) { create(:restaurant) }
+        let(:id) { restaurant.id }
+
+        after do |example|
+          if response&.body
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                examples: { example: { value: JSON.parse(response.body, symbolize_names: true) } }
+              }
+            }
+          end
+        end
+
+        run_test! do
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to eq(RestaurantBlueprint.render(restaurant, view: :detailed))
+        end
+      end
+
+      response 404, 'not found' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        let(:id) { 999 }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,146 @@
+require 'fileutils'
+
+RSpec.configure do |config|
+  config.openapi_root = Rails.root.join('swagger').to_s
+  config.openapi_format = :json
+
+  FileUtils.mkdir_p(File.join(config.openapi_root, 'v1'))
+
+  config.openapi_specs = {
+    'v1/swagger.json' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'Restaurant Menu API',
+        version: 'v1',
+        description: 'API for managing restaurants, menus, and menu items. Supports JSON data import.'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'http://localhost:3000',
+          description: 'Local development server'
+        }
+      ],
+      components: {
+        schemas: {
+          Restaurant: {
+            type: :object,
+            properties: {
+              id: { type: :integer },
+              name: { type: :string },
+              menus: {
+                type: :array,
+                items: { '$ref' => '#/components/schemas/MenuWithItems' }
+              }
+            },
+            required: %w[id name]
+          },
+          Menu: {
+            type: :object,
+            properties: {
+              id: { type: :integer },
+              name: { type: :string }
+            },
+            required: %w[id name]
+          },
+          MenuWithItems: {
+            type: :object,
+            properties: {
+              id: { type: :integer },
+              name: { type: :string },
+              menu_items: {
+                type: :array,
+                items: { '$ref' => '#/components/schemas/MenuItemWithPrice' }
+              }
+            },
+            required: %w[id name]
+          },
+          MenuItem: {
+            type: :object,
+            properties: {
+              id: { type: :integer },
+              name: { type: :string }
+            },
+            required: %w[name]
+          },
+          MenuItemDetails: {
+            type: :object,
+            properties: {
+              id: { type: :integer },
+              name: { type: :string },
+              description: { type: :string, nullable: true }
+            },
+            required: %w[id name]
+          },
+          MenuItemWithPrice: {
+            type: :object,
+            properties: {
+              name: { type: :string },
+              price: { type: :string }
+            },
+            required: %w[name price]
+          },
+          ImportRequest: {
+            type: :object,
+            properties: {
+              restaurants: {
+                type: :array,
+                items: {
+                  type: :object,
+                  properties: {
+                    name: { type: :string },
+                    menus: {
+                      type: :array,
+                      items: {
+                        type: :object,
+                        properties: {
+                          name: { type: :string },
+                          menu_items: {
+                            type: :array,
+                            items: {
+                              type: :object,
+                              properties: {
+                                name: { type: :string },
+                                price: { type: :number, format: :float }
+                              },
+                              required: %w[name price]
+                            }
+                          }
+                        },
+                        required: %w[name menu_items]
+                      }
+                    }
+                  },
+                  required: %w[name menus]
+                }
+              }
+            },
+            required: %w[restaurants]
+          },
+          ImportResponse: {
+            type: :object,
+            properties: {
+              success: { type: :boolean },
+              logs: { type: :array, items: { type: :string } }
+            },
+            required: %w[success logs]
+          },
+          ErrorResponse: {
+            type: :object,
+            properties: {
+              error: { type: :string }
+            },
+            required: %w[error]
+          }
+        }
+      }
+    }
+  }
+
+  config.after(:suite) do
+    config.openapi_specs.each do |path, spec|
+      full_path = File.join(config.openapi_root, path)
+      File.write(full_path, JSON.pretty_generate(spec))
+    end
+  end
+end


### PR DESCRIPTION
The changes add Swagger/OpenAPI documentation for the REST API endpoints, including detailed schema definitions, request/response examples, and interactive documentation UI.